### PR TITLE
docs: add open-source growth plan

### DIFF
--- a/docs/OPEN_SOURCE_GROWTH_PLAN.md
+++ b/docs/OPEN_SOURCE_GROWTH_PLAN.md
@@ -1,0 +1,40 @@
+# Open Source Growth Plan
+
+This plan turns the repository review into a practical backlog for Rakcha.
+
+## Quick wins
+
+- Add screenshots and demo videos for cinema management, streaming, marketplace, QR flows, and admin tools.
+- Add one-command Docker/local setup with seeded demo data.
+- Add architecture documentation for backend, desktop, mobile, web, and shared data contracts.
+- Add CI checks for the main frameworks in the monorepo.
+- Add observability notes for logs, metrics, and tracing.
+- Add `good first issue` tasks for documentation, sample data, tests, and UI polish.
+
+## Bugs and bad practices to watch
+
+- Duplicate business logic across desktop, mobile, web, and backend clients.
+- Tight coupling between domain modules such as cinema, streaming, and commerce.
+- Inconsistent permissions or role checks across clients.
+- QR code and ticket state transitions that are not idempotent.
+- Missing monitoring for payment, notification, and streaming failures.
+
+## Star growth strategy
+
+1. Add a public demo with synthetic cinema, users, products, and media metadata.
+2. Show the platform modules visually above the fold in the README.
+3. Add GitHub topics for cinema, streaming, e-commerce, Flutter, Symfony, and Java.
+4. Publish architecture notes to make the large codebase approachable.
+5. Share individual module demos with relevant communities.
+
+## Trending-library opportunities
+
+- Use Morphik-Core-style document/media search for streaming metadata exploration.
+- Use ChainForge-style prompt testing for recommendation or chatbot experiments.
+- Use Polars and Data-Formulator-style dashboards for commerce and engagement analytics.
+
+## Suggested next PRs
+
+- Add `docs/ARCHITECTURE.md` with bounded contexts and module ownership.
+- Add CI for the primary build/test paths.
+- Add sample data and demo environment setup.


### PR DESCRIPTION
Adds a repository-specific growth plan with quick wins, quality risks, star-growth ideas, and follow-up work. This documentation-only PR does not change runtime behavior.

## Summary by Sourcery

Documentation:
- Introduce OPEN_SOURCE_GROWTH_PLAN documentation covering quick wins, quality risks, star growth strategies, trending-library opportunities, and suggested follow-up PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `docs/OPEN_SOURCE_GROWTH_PLAN.md` outlining quick wins, bugs/risks to watch, star-growth tactics, trending-library ideas, and next PRs. Documentation-only; no code or runtime behavior changes.

<sup>Written for commit e7ab280677ed3f7d7a6346e462eaa1511bf711af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aliammari1/rakcha/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

